### PR TITLE
NFL player name logo

### DIFF
--- a/cfb_abbreviations.json
+++ b/cfb_abbreviations.json
@@ -235,7 +235,7 @@
   "TTU": 104,
   "TEXAS TECH": 104,
   "TLDO": 105,
-  "TOLDEO": 105,
+  "TOLEDO": 105,
   "TROY": 106,
   "TLNE": 107,
   "TULANE": 107,

--- a/cogs/nfl_player_name_stats_attributes.py
+++ b/cogs/nfl_player_name_stats_attributes.py
@@ -27,7 +27,7 @@ class nfl_player_name_attributes(commands.Cog):
                     title = f"{player['FirstName']} {player['LastName']} {player['Position']}"
                 desc = f"{player['Year']} year veteran {player['Archetype']} {player['Position']} Graduated from {player['College']}"
                 attrlist = player_builder.GetPriorityFields(player)
-                logo_url = logos_util.GetLogo(player['Team'])
+                logo_url = logos_util.GetNFLLogo(player['Team'])
                 embed_player = discord.Embed(colour=discord.Colour.gold(),
                                     description=desc,
                                     title=title)


### PR DESCRIPTION
NFL player name attribute was using getlogo instead of getNFLlogo which threw an error and made it so the command wouldn't work. Added NFL between get and logo to fix it and get the command to work.